### PR TITLE
Update `tsconfig.json` to ignore deprecations

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
         "outDir": "./out/",
         "skipLibCheck": true,
         "target": "es2019",
-        "noErrorTruncation": true
+        "noErrorTruncation": true,
+        "ignoreDeprecations": "5.0"
     },
     "include": [
         "src/"


### PR DESCRIPTION
`error TS5101: Option 'charset' is deprecated and will stop functioning in TypeScript 5.5. Specify compilerOption '"ignoreDeprecations": "5.0"' to silence this error.`